### PR TITLE
HEAppE now requires an access token and a refresh token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ export CGO_ENABLED=0
 
 build: format
 	@echo "--> Running go build"
+	@mkdir -p ./bin
 	@go build -o bin/heappe-plugin
 	@echo "--> Embedding HEAppE types in binary"
 	@rm -Rf ./build

--- a/a4c/heappe-types-a4c.yaml
+++ b/a4c/heappe-types-a4c.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.lexis.common.heappe-types
-  template_version: 1.0.3
+  template_version: 1.0.6
   template_author: yorc
 
 imports:
@@ -250,8 +250,12 @@ node_types:
         description: Specification of the job to create
         type: org.lexis.common.heappe.types.JobSpecification
         required: true
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
       listChangedFilesWhileRunning:
@@ -332,11 +336,6 @@ node_types:
     derived_from: org.lexis.common.heappe.nodes.pub.Job
     description: >
       HEAppE Job where tasks parameters are provided by another component
-    properties:
-      token:
-        description: Access token
-        type: string
-        required: false
     requirements:
       - tasks_parameters_provider:
           capability: org.lexis.common.heappe.capabilities.TasksParametersProvider
@@ -357,8 +356,12 @@ node_types:
     description: >
       Wait for the creation of a file by a given job and get its content(abstract)
     properties:
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
       file_path:
@@ -416,8 +419,12 @@ node_types:
     description: >
       Transfer a zipped dataset to a HEAppEJob input files directory (abstract)
     properties:
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
     artifacts:
@@ -461,8 +468,12 @@ node_types:
     description: >
       Get result files from a HEAppEJob (abstract) 
     properties:
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
     attributes:

--- a/collectors/heappecollector/heappeCollector.go
+++ b/collectors/heappecollector/heappeCollector.go
@@ -66,7 +66,7 @@ func (h *heappeUsageCollectorDelegate) CollectInfo(ctx context.Context, cfg conf
 		return nil, err
 	}
 
-	heappeClient, err := heappe.GetClient(locationProps, "")
+	heappeClient, err := heappe.GetClient(locationProps, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/execution.go
+++ b/execution.go
@@ -76,8 +76,14 @@ func newExecution(ctx context.Context, cfg config.Configuration, taskID, deploym
 		monitoringTimeInterval = locationDefaultMonitoringTimeInterval
 	}
 
-	token, err := deployments.GetStringNodePropertyValue(ctx, deploymentID,
-		nodeName, "token")
+	accessToken, err := deployments.GetStringNodePropertyValue(ctx, deploymentID,
+		nodeName, "accessToken")
+	if err != nil {
+		return exec, err
+	}
+
+	refreshToken, err := deployments.GetStringNodePropertyValue(ctx, deploymentID,
+		nodeName, "refreshToken")
 	if err != nil {
 		return exec, err
 	}
@@ -96,7 +102,8 @@ func newExecution(ctx context.Context, cfg config.Configuration, taskID, deploym
 			DeploymentID:           deploymentID,
 			TaskID:                 taskID,
 			NodeName:               nodeName,
-			Token:                  token,
+			AccessToken:            accessToken,
+			RefreshToken:           refreshToken,
 			ListFilesWhileRunning:  listFiles,
 			Operation:              operation,
 			MonitoringTimeInterval: monitoringTimeInterval,
@@ -138,7 +145,8 @@ func newExecution(ctx context.Context, cfg config.Configuration, taskID, deploym
 		DeploymentID:           deploymentID,
 		TaskID:                 taskID,
 		NodeName:               nodeName,
-		Token:                  token,
+		AccessToken:            accessToken,
+		RefreshToken:           refreshToken,
 		Operation:              operation,
 		MonitoringTimeInterval: monitoringTimeInterval,
 	}

--- a/heappe/heappe.go
+++ b/heappe/heappe.go
@@ -68,15 +68,15 @@ type Client interface {
 }
 
 // GetClient returns a HEAppE client for a given location
-func GetClient(locationProps config.DynamicMap, token string) (Client, error) {
+func GetClient(locationProps config.DynamicMap, accessToken, refreshToken string) (Client, error) {
 
 	url := locationProps.GetString(locationURLPropertyName)
 	if url == "" {
 		return nil, errors.Errorf("No URL defined in HEAppE location configuration")
 	}
 
-	if token != "" {
-		return getOpenIDAuthClient(url, token), nil
+	if accessToken != "" {
+		return getOpenIDAuthClient(url, accessToken, refreshToken), nil
 	}
 
 	username := locationProps.GetString(LocationUserPropertyName)
@@ -89,12 +89,13 @@ func GetClient(locationProps config.DynamicMap, token string) (Client, error) {
 }
 
 // getOpenIDAuthClient returns a client performing an OpenID connect token-based authentication
-func getOpenIDAuthClient(url, token string) Client {
+func getOpenIDAuthClient(url, accessToken, refreshToken string) Client {
 	return &heappeClient{
 		openIDAuth: OpenIDAuthentication{
 			Credentials: OpenIDCredentials{
-				Username:          "YorcUser",
-				OpenIdAccessToken: token,
+				Username:           "YorcUser",
+				OpenIdAccessToken:  accessToken,
+				OpenIdRefreshToken: refreshToken,
 			},
 		},
 		httpClient: getHTTPClient(url),

--- a/heappe/heappe_structs.go
+++ b/heappe/heappe_structs.go
@@ -42,10 +42,11 @@ type Authentication struct {
 	Credentials PasswordCredentials
 }
 
-// OpenIDCredentials holds an OPenID token and user name to perform a token-based authentication
+// OpenIDCredentials holds OpenID access and refresh tokens and user name to perform a token-based authentication
 type OpenIDCredentials struct {
-	OpenIdAccessToken string
-	Username          string
+	OpenIdAccessToken  string
+	OpenIdRefreshToken string
+	Username           string
 }
 
 // Authentication parameters

--- a/job/dataset_transfer_execution.go
+++ b/job/dataset_transfer_execution.go
@@ -55,7 +55,8 @@ type DatasetTransferExecution struct {
 	DeploymentID           string
 	TaskID                 string
 	NodeName               string
-	Token                  string
+	AccessToken            string
+	RefreshToken           string
 	Operation              prov.Operation
 	OverlayPath            string
 	Artifacts              map[string]string
@@ -90,7 +91,8 @@ func (e *DatasetTransferExecution) ExecuteAsync(ctx context.Context) (*prov.Acti
 	data["taskID"] = e.TaskID
 	data["nodeName"] = e.NodeName
 	data["jobID"] = jobIDStr
-	data["token"] = e.Token
+	data["accessToken"] = e.AccessToken
+	data["refreshToken"] = e.RefreshToken
 
 	return &prov.Action{ActionType: "heappe-filecontent-monitoring", Data: data}, e.MonitoringTimeInterval, err
 
@@ -155,7 +157,7 @@ func (e *DatasetTransferExecution) ResolveExecution(ctx context.Context) error {
 
 func (e *DatasetTransferExecution) transferDataset(ctx context.Context) error {
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -250,7 +252,7 @@ func (e *DatasetTransferExecution) getDatasetFileNames(jobID int64) ([]string, e
 func (e *DatasetTransferExecution) getResultFiles(ctx context.Context) error {
 
 	// Get details on remote host where to get result files
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}

--- a/job/job_execution.go
+++ b/job/job_execution.go
@@ -66,7 +66,8 @@ type Execution struct {
 	DeploymentID           string
 	TaskID                 string
 	NodeName               string
-	Token                  string
+	AccessToken            string
+	RefreshToken           string
 	ListFilesWhileRunning  bool
 	Operation              prov.Operation
 	MonitoringTimeInterval time.Duration
@@ -89,7 +90,8 @@ func (e *Execution) ExecuteAsync(ctx context.Context) (*prov.Action, time.Durati
 	data["taskID"] = e.TaskID
 	data["nodeName"] = e.NodeName
 	data["jobID"] = strconv.FormatInt(jobID, 10)
-	data["token"] = e.Token
+	data["accessToken"] = e.AccessToken
+	data["refreshToken"] = e.RefreshToken
 	data[listChangedFilesAction] = strconv.FormatBool(e.ListFilesWhileRunning)
 
 	return &prov.Action{ActionType: "heappe-job-monitoring", Data: data}, e.MonitoringTimeInterval, err
@@ -210,7 +212,7 @@ func (e *Execution) createJob(ctx context.Context) error {
 	events.WithContextOptionalFields(ctx).NewLogEntry(events.LogLevelINFO, e.DeploymentID).Registerf(
 		"Creating job %+v ", jobSpec)
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -294,7 +296,7 @@ func (e *Execution) deleteJob(ctx context.Context) error {
 		return err
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -309,7 +311,7 @@ func (e *Execution) submitJob(ctx context.Context) error {
 		return err
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -324,7 +326,7 @@ func (e *Execution) enableFileTransfer(ctx context.Context) error {
 		return err
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -344,7 +346,7 @@ func (e *Execution) disableFileTransfer(ctx context.Context) error {
 		return err
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -390,7 +392,7 @@ func (e *Execution) listChangedFiles(ctx context.Context) error {
 		return err
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -451,7 +453,7 @@ func (e *Execution) cancelJob(ctx context.Context) error {
 		return err
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.Token)
+	heappeClient, err := getHEAppEClient(ctx, e.Cfg, e.DeploymentID, e.NodeName, e.AccessToken, e.RefreshToken)
 	if err != nil {
 		return err
 	}
@@ -847,7 +849,7 @@ func getBoolNodePropertyValue(ctx context.Context, deploymentID, nodeName, prope
 	return result, err
 }
 
-func getHEAppEClient(ctx context.Context, cfg config.Configuration, deploymentID, nodeName, token string) (heappe.Client, error) {
+func getHEAppEClient(ctx context.Context, cfg config.Configuration, deploymentID, nodeName, accessToken, refreshToken string) (heappe.Client, error) {
 	locationMgr, err := locations.GetManager(cfg)
 	if err != nil {
 		return nil, err
@@ -859,5 +861,5 @@ func getHEAppEClient(ctx context.Context, cfg config.Configuration, deploymentID
 		return nil, err
 	}
 
-	return heappe.GetClient(locationProps, token)
+	return heappe.GetClient(locationProps, accessToken, refreshToken)
 }

--- a/job/monitoring_jobs.go
+++ b/job/monitoring_jobs.go
@@ -115,7 +115,7 @@ func (o *ActionOperator) monitorJob(ctx context.Context, cfg config.Configuratio
 	if ok {
 		listChangedFilesWhileRunning, _ = strconv.ParseBool(boolStr)
 	}
-	heappeClient, err := getHEAppEClient(ctx, cfg, deploymentID, actionData.nodeName, action.Data["token"])
+	heappeClient, err := getHEAppEClient(ctx, cfg, deploymentID, actionData.nodeName, action.Data["accessToken"], action.Data["refreshToken"])
 	if err != nil {
 		return true, err
 	}
@@ -313,7 +313,7 @@ func (o *ActionOperator) getFileContent(ctx context.Context, cfg config.Configur
 		return true, errors.Errorf("Missing mandatory information filePath for actionType:%q", action.ActionType)
 	}
 
-	heappeClient, err := getHEAppEClient(ctx, cfg, deploymentID, actionData.nodeName, action.Data["token"])
+	heappeClient, err := getHEAppEClient(ctx, cfg, deploymentID, actionData.nodeName, action.Data["accessToken"], action.Data["refreshToken"])
 	if err != nil {
 		return true, err
 	}

--- a/tosca/heappe-types.yaml
+++ b/tosca/heappe-types.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: yorc_tosca_simple_yaml_1_0
 
 metadata:
   template_name: org.lexis.common.heappe-types
-  template_version: 1.0.3
+  template_version: 1.0.6
   template_author: lexis
 
 imports:
@@ -230,8 +230,12 @@ node_types:
         description: Specification of the job to create
         type: org.lexis.common.heappe.types.JobSpecification
         required: true
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
       listChangedFilesWhileRunning:
@@ -308,11 +312,6 @@ node_types:
     derived_from: org.lexis.common.heappe.nodes.pub.Job
     description: >
       HEAppE Job where tasks parameters are provided by another component
-    properties:
-      token:
-        description: Access token
-        type: string
-        required: false
     requirements:
       - tasks_parameters_provider:
           capability: org.lexis.common.heappe.capabilities.TasksParametersProvider
@@ -333,8 +332,12 @@ node_types:
     description: >
       Wait for the creation of a file by a given job and get its content(abstract)
     properties:
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
       file_path:
@@ -390,8 +393,12 @@ node_types:
     description: >
       Transfer a zipped dataset to a HEAppEJob input files directory (abstract)
     properties:
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
     artifacts:
@@ -434,8 +441,12 @@ node_types:
     description: >
       Get result files from a HEAppEJob (abstract)
     properties:
-      token:
-        description: Access token
+      accessToken:
+        description: OpenID Connect Access token
+        type: string
+        required: false
+      refreshToken:
+        description: OpenID Connect Refresh token
         type: string
         required: false
     attributes:


### PR DESCRIPTION
The HEAppE API now requires an access token and a refresh token