### PR TITLE
Expose the HEAppE instance URL as a HEAppE job attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/heappe-plugin
 build
+bin
 

--- a/a4c/heappe-types-a4c.yaml
+++ b/a4c/heappe-types-a4c.yaml
@@ -268,6 +268,10 @@ node_types:
         type: string
         description: >
           ID of the HEAppE job created
+      heappe_url:
+        type: string
+        description: >
+          URL of the HEAppE instance on which the job is created
       file_transfer:
         type: org.lexis.common.heappe.types.FileTransfer
         description: >

--- a/heappe/heappe.go
+++ b/heappe/heappe.go
@@ -56,6 +56,7 @@ type Client interface {
 	GetJobInfo(jobID int64) (JobInfo, error)
 	SetSessionID(sessionID string)
 	GetSessionID() string
+	GetURL() string
 	DownloadPartsOfJobFilesFromCluster(JobID int64, offsets []TaskFileOffset) ([]JobFileContent, error)
 	GetFileTransferMethod(jobID int64) (FileTransferMethod, error)
 	EndFileTransfer(jobID int64, ft FileTransferMethod) error
@@ -130,6 +131,11 @@ func (h *heappeClient) SetSessionID(sessionID string) {
 // GetSessionID sets a HEAppE session ID
 func (h *heappeClient) GetSessionID() string {
 	return h.sessionID
+}
+
+// GetURL returns the URL of the HEAppE instance
+func (h *heappeClient) GetURL() string {
+	return h.httpClient.baseURL
 }
 
 // CreateJob creates a HEAppE job

--- a/job/job_execution.go
+++ b/job/job_execution.go
@@ -47,6 +47,7 @@ const (
 	jobSpecificationProperty      = "JobSpecification"
 	infrastructureType            = "heappe"
 	jobIDConsulAttribute          = "job_id"
+	heappeURLConsulAttribute      = "heappe_url"
 	transferUser                  = "user"
 	transferKey                   = "key"
 	transferServer                = "server"
@@ -227,6 +228,14 @@ func (e *Execution) createJob(ctx context.Context) error {
 		jobIDConsulAttribute, strconv.FormatInt(jobInfo.ID, 10))
 	if err != nil {
 		err = errors.Wrapf(err, "Job %d created on HEAppE, but failed to store this job id", jobInfo.ID)
+		return err
+	}
+
+	// Store the URL of the HEAppE instance where this job is created
+	err = deployments.SetAttributeForAllInstances(ctx, e.DeploymentID, e.NodeName,
+		heappeURLConsulAttribute, heappeClient.GetURL())
+	if err != nil {
+		err = errors.Wrapf(err, "Job %d created on HEAppE, but failed to store the HEAppE instancel URL %s", jobInfo.ID, heappeClient.GetURL())
 		return err
 	}
 
@@ -860,6 +869,5 @@ func getHEAppEClient(ctx context.Context, cfg config.Configuration, deploymentID
 	if err != nil {
 		return nil, err
 	}
-
 	return heappe.GetClient(locationProps, accessToken, refreshToken)
 }

--- a/tosca/heappe-types.yaml
+++ b/tosca/heappe-types.yaml
@@ -248,6 +248,10 @@ node_types:
         type: string
         description: >
           ID of the HEAppE job created
+      heappe_url:
+        type: string
+        description: >
+          URL of the HEAppE instance on which the job is created
       file_transfer:
         type: org.lexis.common.heappe.types.FileTransfer
         description: >


### PR DESCRIPTION
Added a HEAppE URL attribute to the HEAppE job TOSCA component, so that clients like the Yorc DDI plugin perfoming a HPC datatransfer know on which HEAppE instance a HEApPE job is created

Closes #11 