### PR TITLE
Added a function to get OpenStack application credentials from HEAppE

### DIFF
--- a/heappe/heappe_structs.go
+++ b/heappe/heappe_structs.go
@@ -37,6 +37,12 @@ type PasswordCredentials struct {
 	Password string
 }
 
+// OpenStackCredentials holds OpenStack application credentials
+type OpenStackCredentials struct {
+	ApplicationCredentialsId     string
+	ApplicationCredentialsSecret string
+}
+
 // Authentication parameters
 type Authentication struct {
 	Credentials PasswordCredentials

--- a/job/monitoring_jobs.go
+++ b/job/monitoring_jobs.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lexis-project/yorc-heappe-plugin/heappe"
 	"github.com/pkg/errors"
@@ -157,11 +158,25 @@ func (o *ActionOperator) monitorJob(ctx context.Context, cfg config.Configuratio
 	// See if monitoring must be continued and set job state if terminated
 	switch jobState {
 	case jobStateCompleted:
-		// job has been done successfully : unregister monitoring
-		err = updateListOfChangedFiles(ctx, heappeClient, deploymentID, actionData.nodeName, actionData.jobID)
-		if err != nil {
-			log.Printf("Failed to update list of files changed by Job %d : %s", actionData.jobID, err.Error())
+		// job has been done successfully : update the list of changed files
+		nbAttempts := 0
+		for err != nil || nbAttempts == 0 {
+			nbAttempts++
+			err = updateListOfChangedFiles(ctx, heappeClient, deploymentID, actionData.nodeName, actionData.jobID)
+			if err != nil {
+				// Be resilient to temporary gateway errors here
+				nonFatalError := strings.Contains(err.Error(), "502 Bad Gateway") ||
+					strings.Contains(err.Error(), "504 Gateway Time-out") || strings.Contains(err.Error(), "i/o timeout")
+
+				if nonFatalError && nbAttempts < 10 {
+					log.Printf("Ignoring non fatal error trying to get job info: %s", err.Error())
+					time.Sleep(30 * time.Second)
+				} else {
+					log.Printf("Failed to update list of files changed by Job %d : %s", actionData.jobID, err.Error())
+				}
+			}
 		}
+		// job has been done successfully : unregister monitoring
 		deregister = true
 	case jobStatePending:
 		// Not yet running: monitoring is keeping on (deregister stays false)


### PR DESCRIPTION
Added a function to get OpenStack application credentials from HEAppE
Being more resilient to intermittent failure getting the list of changed files from HEappE once the job is finished