### PR TITLE
Missing e-mail notification in requests sent tho HEAppE

### DIFF
--- a/job/job_execution.go
+++ b/job/job_execution.go
@@ -588,7 +588,7 @@ func (e *Execution) getJobSpecification(ctx context.Context) (heappe.JobSpecific
 		{field: &(jobSpec.Name), propName: "Name"},
 		{field: &(jobSpec.Project), propName: "Project"},
 		{field: &(jobSpec.NotificationEmail), propName: "NotificationEmail"},
-		{field: &(jobSpec.NotificationEmail), propName: "PhoneNumber"},
+		{field: &(jobSpec.PhoneNumber), propName: "PhoneNumber"},
 	}
 
 	for _, stringPropName := range stringPropNames {


### PR DESCRIPTION

Fixed an error setting the phone number that was erasing the email value

Closes #19 